### PR TITLE
Better type checking and handling of null values

### DIFF
--- a/Classes/NSManagedObject+DataMapping.m
+++ b/Classes/NSManagedObject+DataMapping.m
@@ -380,7 +380,7 @@ NSUInteger kKernArrayIndexRelationshipBlock = 2;
         
         id aValue = [objAttributes valueForKey:remoteKey];
         
-        if ([dataType isEqualToString:KernDataTypeRelationshipBlock]) {
+        if (aValue && ![aValue isEqual:[NSNull null]] && [dataType isEqualToString:KernDataTypeRelationshipBlock]) {
             [[Kern sharedContext].parentContext performBlockAndWait:^{
                 KernCoreDataRelationshipBlock blk = (KernCoreDataRelationshipBlock)[mappedItemAttributes objectAtIndex:kKernArrayIndexRelationshipBlock];
                 blk(obj, aValue, attributeName, remoteKey);

--- a/Classes/NSManagedObject+DataMapping.m
+++ b/Classes/NSManagedObject+DataMapping.m
@@ -378,9 +378,9 @@ NSUInteger kKernArrayIndexRelationshipBlock = 2;
     if ([objAttributes isEqual:[NSNull null]] || ([objAttributes isKindOfClass:[NSDictionary class]] && [[objAttributes allKeys] containsObject:remoteKey])) {
         NSString *dataType = [mappedItemAttributes objectAtIndex:kKernArrayIndexDataType];
         
-        id aValue = [objAttributes valueForKey:remoteKey];
+        id aValue = [objAttributes isKindOfClass:[NSDictionary class]] ? [objAttributes valueForKey:remoteKey] : nil;
         
-        if (aValue && ![aValue isEqual:[NSNull null]] && [dataType isEqualToString:KernDataTypeRelationshipBlock]) {
+        if ([dataType isEqualToString:KernDataTypeRelationshipBlock]) {
             [[Kern sharedContext].parentContext performBlockAndWait:^{
                 KernCoreDataRelationshipBlock blk = (KernCoreDataRelationshipBlock)[mappedItemAttributes objectAtIndex:kKernArrayIndexRelationshipBlock];
                 blk(obj, aValue, attributeName, remoteKey);

--- a/Classes/NSManagedObject+DataMapping.m
+++ b/Classes/NSManagedObject+DataMapping.m
@@ -373,9 +373,9 @@ NSUInteger kKernArrayIndexRelationshipBlock = 2;
 + (void) parseAttributes:(NSString*)attributeName mappedItemAttributes:(NSArray*)mappedItemAttributes objAttributes:(NSDictionary*)objAttributes
                      obj:(NSManagedObject*)obj convertedAttributes:(NSMutableDictionary*)convertedAttributes
 {
+    // Only process the key if it's in the remote dictionary, or if it's null (to persist null to the DB).
     NSString *remoteKey = [mappedItemAttributes objectAtIndex:kKernArrayIndexRemoteKey];
-    // only process key if it's in our provided set
-    if ([[objAttributes allKeys] containsObject:remoteKey]) {
+    if ([objAttributes isEqual:[NSNull null]] || ([objAttributes isKindOfClass:[NSDictionary class]] && [[objAttributes allKeys] containsObject:remoteKey])) {
         NSString *dataType = [mappedItemAttributes objectAtIndex:kKernArrayIndexDataType];
         
         id aValue = [objAttributes valueForKey:remoteKey];

--- a/Project/KernExampleAppTests/KernExampleAppTests.m
+++ b/Project/KernExampleAppTests/KernExampleAppTests.m
@@ -452,6 +452,30 @@
     XCTAssertEqualObjects(u.timeStamp, [NSDate dateWithTimeIntervalSince1970:0], @"timeStamp must match supplied value in JSON");
 }
 
+- (void)testCreatesAnEntityWithRemoteDictionaryNestedNull {
+    
+    NSMutableDictionary *json = [self baseRemoteDictionaryNested];
+    json[@"name"] = [NSNull null];
+    
+    Dude *aDude = [Dude updateOrCreateEntityUsingRemoteDictionary:json];
+    
+    XCTAssertNil(aDude.firstName, @"firstName must be NULL");
+    XCTAssertNil(aDude.lastName, @"firstName must be NULL");
+}
+
+- (void)testUpdatesAnExistingEntityWithRemoteDictionaryNestedNull {
+    
+    Dude *dudeOne = [self dudeFromRemoteDictionaryNested];
+    
+    NSMutableDictionary *json = [self baseRemoteDictionaryNested];
+    json[@"name"] = [NSNull null];
+    
+    [Dude updateOrCreateEntityUsingRemoteDictionary:json];
+    
+    XCTAssertNil(dudeOne.firstName, @"firstName must be NULL");
+    XCTAssertNil(dudeOne.lastName, @"firstName must be NULL");
+}
+
 - (void)testUpdatesAnExistingEntityWithRemoteDictionary {
     User *u1 = [self userFromRemoteDictionary];
     

--- a/Project/KernExampleAppTests/KernExampleAppTests.m
+++ b/Project/KernExampleAppTests/KernExampleAppTests.m
@@ -460,7 +460,7 @@
     Dude *aDude = [Dude updateOrCreateEntityUsingRemoteDictionary:json];
     
     XCTAssertNil(aDude.firstName, @"firstName must be NULL");
-    XCTAssertNil(aDude.lastName, @"firstName must be NULL");
+    XCTAssertNil(aDude.lastName, @"lastName must be NULL");
 }
 
 - (void)testUpdatesAnExistingEntityWithRemoteDictionaryNestedNull {
@@ -473,7 +473,7 @@
     [Dude updateOrCreateEntityUsingRemoteDictionary:json];
     
     XCTAssertNil(dudeOne.firstName, @"firstName must be NULL");
-    XCTAssertNil(dudeOne.lastName, @"firstName must be NULL");
+    XCTAssertNil(dudeOne.lastName, @"lastName must be NULL");
 }
 
 - (void)testUpdatesAnExistingEntityWithRemoteDictionary {


### PR DESCRIPTION
- Add type checking to prevent crashing when the passed attributes object is not a dictionary.
- Add type checking to allow processing of null objects so they can be persisted to the DB in nested responses.